### PR TITLE
Smoother Ansible Tower workflow schema with tower-cli update

### DIFF
--- a/reference-architecture/ansible-tower-integration/tower_config/schema.yml
+++ b/reference-architecture/ansible-tower-integration/tower_config/schema.yml
@@ -1,6 +1,6 @@
 - job_template: aws-infrastructure
   success_nodes:
-REPLACEME
+  - inventory_source: aws (aws-inventory
     success_nodes:
     - job_template: aws-openshift-install
       success_nodes:

--- a/reference-architecture/ansible-tower-integration/tower_config/tower_config/tasks/main.yaml
+++ b/reference-architecture/ansible-tower-integration/tower_config/tower_config/tasks/main.yaml
@@ -96,10 +96,6 @@
     state: present
     tower_config_file: "~/.tower_cli.cfg"
 
-- name: Get Inventory Source ID
-  shell: curl -s -k -u {{ TOWER_USER }}:{{ TOWER_PASSWORD }} https://{{ TOWER_HOSTNAME }}/api/v1/inventory_sources/ | python -m json.tool | grep -m 1 id |awk -F":" '{print $2}' |awk -F"," '{print $1}' |sed 's/^[ \t]*//;s/[ \t]*$//'
-  register: myoutput
-
 - name: Create aws-infrastructure job template
   become: true
   tower_job_template:
@@ -153,19 +149,7 @@
 - name: Create workflow-ocp-aws-install
   command: tower-cli workflow create --name="workflow-ocp-aws-install" --organization="Default" --description="A workflow for deploying OCP on AWS" -e @workflow-ocp-aws-install-extravars.yaml
 
-- name: Replace inventory source
-  lineinfile:
-    path: schema.yml
-    regexp: '^REPLACEME'
-    line: '  - inventory_source: aws (aws-inventory - {{ myoutput.stdout }})'
-
 - name: Create a schema for workflow-ocp-aws-install
   command: tower-cli workflow schema workflow-ocp-aws-install @schema.yml
-
-- name: Reset schema file in case we run again
-  lineinfile:
-     path: schema.yml
-     regexp: '^(.*)inventory_source'
-     line: 'REPLACEME'
 
 


### PR DESCRIPTION
We released a new version of Ansible Tower CLI (`pip install ansible-tower-cli==3.1.5`) that should make this less painful.

The schema here will look for an inventory source with a name that starts with "aws (awx-inventory", where inventory sources have a name automatically generated starting with the group name, and then the inventory name. I would strongly suggest using a more specific group name, because groups are unique by (group name, inventory name, organization name), so the playbook could break (with multiple objects returned type error) if another user of the same Tower instance created another organization that had an inventory and group with the same names.

There are plans to add these workflow commands to the Ansible tower modules, but we don't have that yet.

More workflow examples are at https://github.com/ansible/tower-cli/tree/master/docs/examples